### PR TITLE
Feature/4.3.3 duracao config

### DIFF
--- a/.postman/resources.yaml
+++ b/.postman/resources.yaml
@@ -1,0 +1,9 @@
+# Use this workspace to collaborate
+workspace:
+  id: d9920d68-8e92-421c-b516-5e97f435a25a
+
+# All resources in the `postman/` folder are automatically registered in Local View.
+# Point to additional files outside the `postman/` folder to register them individually. Example:
+#localResources:
+#  collections:
+#    - ../tests/E2E Test Collection/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NutriPI
 
-Plataforma web de marcação de consultas para consultórios, com foco em **agendamento direto pelo paciente**, **organização da grade médica** e **redução de faltas (absenteísmo)** por meio de fluxo digital integrado.
+Plataforma web de marcação de consultas para consultórios de nutrição, com foco em **agendamento direto pelo paciente**, **organização da grade do nutricionista** e **redução de faltas (absenteísmo)** por meio de fluxo digital integrado.
 
 ---
 
@@ -8,7 +8,7 @@ Plataforma web de marcação de consultas para consultórios, com foco em **agen
 
 O **NutriPI** nasce para substituir processos manuais de agendamento por uma experiência digital simples e centralizada, conectando:
 
-- **Médico**, que configura sua disponibilidade de atendimento;
+- **Nutricionista**, que configura sua disponibilidade de atendimento;
 - **Paciente**, que visualiza horários e realiza reservas pela área logada;
 - **Recepção**, que acompanha e gerencia o status das consultas.
 
@@ -26,7 +26,7 @@ No MVP, o sistema prioriza rapidez de operação, clareza no fluxo de marcação
 
 ### 2.2 Escopo
 
-O objetivo primordial do software é **automatizar a gestão de agendamentos em consultórios médicos**, eliminando tarefas manuais e combatendo faltas com notificações e controle de status.
+O objetivo primordial do software é **automatizar a gestão de agendamentos em consultórios de nutrição**, eliminando tarefas manuais e combatendo faltas com notificações e controle de status.
 
 O foco inicial está em:
 
@@ -58,7 +58,7 @@ O produto entrega uma plataforma de agendamento direto onde o consultório publi
 
 ### Incluído no MVP
 
-- Configuração de grade de horários do médico;
+- Configuração de grade de horários do nutricionista;
 - Visualização de disponibilidade para agendamento;
 - Agendamento direto pelo paciente em área autenticada;
 - Cadastro básico de paciente no primeiro agendamento;
@@ -80,7 +80,7 @@ O produto entrega uma plataforma de agendamento direto onde o consultório publi
 
 | Cod. | Nome                    | Descrição |
 |------|-------------------------|-----------|
-| F01  | Configuração de Grade   | O sistema deve permitir que o médico defina dias, horários de atendimento e duração padrão das consultas. |
+| F01  | Configuração de Grade   | O sistema deve permitir que o nutricionista defina dias, horários de atendimento e duração padrão das consultas. |
 | F02  | Agendamento Direto      | O paciente deve conseguir visualizar horários disponíveis e realizar reserva pela área logada do site. |
 | F03  | Gestão de Status        | A recepção deve poder marcar consultas como **Confirmada** ou **Cancelada**. |
 | F04  | Cadastro de Pacientes   | O sistema deve permitir registro básico de dados do paciente no momento do primeiro agendamento. |
@@ -100,7 +100,7 @@ O produto entrega uma plataforma de agendamento direto onde o consultório publi
 
 ```mermaid
 graph LR
-    Medico((Médico))
+    Nutricionista((Nutricionista))
     Paciente((Paciente))
     Recepcao((Recepção))
 
@@ -116,7 +116,7 @@ graph LR
         UC4 -. "<<extend>>" .-> UC2
     end
 
-    Medico --- UC1
+    Nutricionista --- UC1
     Paciente --- UC2
     Paciente --- UC5
     Recepcao --- UC6
@@ -124,7 +124,7 @@ graph LR
 
 ### 5.1 Atores
 
-- **Médico**: define agenda e janelas de atendimento.
+- **Nutricionista**: define agenda e janelas de atendimento.
 - **Paciente**: consulta disponibilidade, agenda e cancela consultas.
 - **Recepção**: valida atendimento operacional confirmando ou cancelando status.
 
@@ -137,7 +137,7 @@ graph LR
 
 ## 6. Personas do Sistema
 
-### 6.1 Persona 1 — Médico (Gestor de Agenda)
+### 6.1 Persona 1 — Nutricionista (Gestor de Agenda)
 
 - **Nome representativo**: Dr. Rafael (Nutrólogo/Nutricionista)
 - **Objetivo principal**: manter agenda organizada e previsível.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,206 @@
-# Nutri-PI
-𝗣𝗿𝗼𝗷𝗲𝘁𝗼 𝗜𝗻𝘁𝗲𝗴𝗿𝗮𝗱𝗼𝗿: 𝗗𝗲𝘀𝗲𝗻𝘃𝗼𝗹𝘃𝗶𝗺𝗲𝗻𝘁𝗼 𝗱𝗲 𝗦𝗶𝘀𝘁𝗲𝗺𝗮𝘀 𝗢𝗿𝗶𝗲𝗻𝘁𝗮𝗱𝗼𝘀 𝗮 𝗪𝗲𝗯 (𝗦𝗘𝗡𝗔𝗖-𝗦𝗣) Desenvolvimento da plataforma de agendamento para nutricionistas. Projeto pautado em metodologias ágeis (Scrum), com separação rigorosa entre Backend e Frontend e persistência de dados estruturada.
+# NutriPI
+
+Plataforma web de marcação de consultas para consultórios, com foco em **agendamento direto pelo paciente**, **organização da grade médica** e **redução de faltas (absenteísmo)** por meio de fluxo digital integrado.
+
+---
+
+## 1. Visão Geral do Produto
+
+O **NutriPI** nasce para substituir processos manuais de agendamento por uma experiência digital simples e centralizada, conectando:
+
+- **Médico**, que configura sua disponibilidade de atendimento;
+- **Paciente**, que visualiza horários e realiza reservas pela área logada;
+- **Recepção**, que acompanha e gerencia o status das consultas.
+
+No MVP, o sistema prioriza rapidez de operação, clareza no fluxo de marcação e base de dados padronizada para sustentar evoluções futuras do ecossistema.
+
+---
+
+## 2. Documento de Visão
+
+### 2.1 Histórico de Revisão
+
+| Data       | Versão | Descrição                         | Autores |
+|------------|--------|-----------------------------------|---------|
+| 04/03/2026 | 1.0    | Início do esboço do projeto       | Thiago Mendes Jatobá; Gabriel Lima; Gabriel Silva Gomes; Débora dos Santos da Silva; Marcos Paulo Santos Boe |
+
+### 2.2 Escopo
+
+O objetivo primordial do software é **automatizar a gestão de agendamentos em consultórios médicos**, eliminando tarefas manuais e combatendo faltas com notificações e controle de status.
+
+O foco inicial está em:
+
+- eficiência operacional interna do consultório;
+- conveniência para pacientes já vinculados à clínica;
+- consolidação de uma base de dados estruturada e consistente.
+
+### 2.3 Estratégia de Evolução
+
+A solução é concebida para escalar tecnicamente, com arquitetura preparada para:
+
+- atender múltiplos clientes em infraestrutura compartilhada (modelo multi-cliente);
+- manter isolamento operacional por consultório;
+- permitir evolução modular sem refatorar o núcleo.
+
+Módulos futuros previstos (fora do MVP):
+
+- triagem avançada;
+- faturamento hospitalar;
+- ecossistema ampliado de serviços de saúde.
+
+### 2.4 Resumo Executivo
+
+O produto entrega uma plataforma de agendamento direto onde o consultório publica sua grade e o paciente reserva horários pela aplicação web. O processo é apoiado por lembretes automáticos e por um painel simplificado para a recepção.
+
+---
+
+## 3. Escopo do MVP
+
+### Incluído no MVP
+
+- Configuração de grade de horários do médico;
+- Visualização de disponibilidade para agendamento;
+- Agendamento direto pelo paciente em área autenticada;
+- Cadastro básico de paciente no primeiro agendamento;
+- Gestão de status da consulta pela recepção (confirmar/cancelar);
+- Cancelamento de consulta pelo paciente (conforme diagrama de caso de uso).
+
+### Explicitamente fora do MVP
+
+- Motor de busca global de profissionais;
+- Gestão complexa de convênios;
+- Prontuário eletrônico completo;
+- Módulos financeiros.
+
+---
+
+## 4. Requisitos
+
+### 4.1 Requisitos Funcionais
+
+| Cod. | Nome                    | Descrição |
+|------|-------------------------|-----------|
+| F01  | Configuração de Grade   | O sistema deve permitir que o médico defina dias, horários de atendimento e duração padrão das consultas. |
+| F02  | Agendamento Direto      | O paciente deve conseguir visualizar horários disponíveis e realizar reserva pela área logada do site. |
+| F03  | Gestão de Status        | A recepção deve poder marcar consultas como **Confirmada** ou **Cancelada**. |
+| F04  | Cadastro de Pacientes   | O sistema deve permitir registro básico de dados do paciente no momento do primeiro agendamento. |
+
+### 4.2 Requisitos Não Funcionais
+
+| Cod. | Nome                  | Descrição |
+|------|-----------------------|-----------|
+| NF01 | Segurança (LGPD)      | Dados de saúde e identificação devem ser criptografados e armazenados conforme a LGPD. |
+| NF02 | Disponibilidade       | O paciente pode acessar sua área logada a qualquer momento para consultar informações. |
+| NF03 | Responsividade        | A interface de agendamento deve ser otimizada para dispositivos móveis (mobile-first). |
+| NF04 | Interface Intuitiva   | A solução deve ser simples de consultar, fácil de usar e preparada para escalar. |
+
+---
+
+## 5. Diagrama de Casos de Uso (MVP)
+
+```mermaid
+graph LR
+    Medico((Médico))
+    Paciente((Paciente))
+    Recepcao((Recepção))
+
+    subgraph "Sistema de Marcação de Consultas (MVP)"
+        UC1([Configurar Grade de Horários])
+        UC2([Realizar Agendamento])
+        UC3([Visualizar Disponibilidade])
+        UC4([Realizar Cadastro Básico])
+        UC5([Cancelar Consulta])
+        UC6([Gerenciar Status: Confirmar/Cancelar])
+
+        UC2 -. "<<include>>" .-> UC3
+        UC4 -. "<<extend>>" .-> UC2
+    end
+
+    Medico --- UC1
+    Paciente --- UC2
+    Paciente --- UC5
+    Recepcao --- UC6
+```
+
+### 5.1 Atores
+
+- **Médico**: define agenda e janelas de atendimento.
+- **Paciente**: consulta disponibilidade, agenda e cancela consultas.
+- **Recepção**: valida atendimento operacional confirmando ou cancelando status.
+
+### 5.2 Relações importantes
+
+- **Realizar Agendamento** inclui **Visualizar Disponibilidade**.
+- **Realizar Cadastro Básico** estende **Realizar Agendamento** quando o paciente ainda não possui registro.
+
+---
+
+## 6. Personas do Sistema
+
+### 6.1 Persona 1 — Médico (Gestor de Agenda)
+
+- **Nome representativo**: Dr. Rafael (Nutrólogo/Nutricionista)
+- **Objetivo principal**: manter agenda organizada e previsível.
+- **Necessidades**:
+  - configurar dias e horários de atendimento com facilidade;
+  - reduzir conflitos de agenda e horários vagos;
+  - ter segurança de que a recepção acompanha o status das consultas.
+- **Dores atuais**:
+  - remarcações manuais;
+  - dificuldade de consolidar agenda em canais dispersos.
+- **Como o NutriPI ajuda**:
+  - centraliza a grade de horários;
+  - padroniza reservas em um fluxo único.
+
+### 6.2 Persona 2 — Paciente (Usuário de Autoatendimento)
+
+- **Nome representativo**: Ana, 29 anos
+- **Objetivo principal**: marcar consulta de forma rápida e sem contato telefônico.
+- **Necessidades**:
+  - visualizar horários disponíveis em tempo real;
+  - concluir agendamento em poucos passos;
+  - acessar o sistema pelo celular com boa usabilidade;
+  - cancelar consulta quando necessário.
+- **Dores atuais**:
+  - demora em retorno por telefone/mensagem;
+  - falta de clareza sobre horários livres.
+- **Como o NutriPI ajuda**:
+  - oferece autoatendimento web em área autenticada;
+  - melhora experiência com interface responsiva e intuitiva.
+
+### 6.3 Persona 3 — Recepção (Operação Administrativa)
+
+- **Nome representativo**: Carla, recepcionista
+- **Objetivo principal**: manter controle diário da agenda e confirmar presença.
+- **Necessidades**:
+  - visualizar rapidamente consultas agendadas;
+  - alterar status para **Confirmada** ou **Cancelada**;
+  - reduzir erros operacionais e retrabalho.
+- **Dores atuais**:
+  - excesso de atualizações manuais;
+  - inconsistência de informações entre canais.
+- **Como o NutriPI ajuda**:
+  - fornece painel administrativo com visão centralizada;
+  - simplifica gestão de status em fluxo único.
+
+---
+
+## 7. Protótipos de Tela
+
+Protótipos disponíveis no Figma:  
+https://www.figma.com/design/WssgymwKX8ejjgaBu1Wrj6/NutriPi?node-id=0-1&p=f
+
+---
+
+## 8. Diretrizes de Qualidade do Produto
+
+- **Segurança e conformidade**: tratamento de dados conforme LGPD.
+- **Alta disponibilidade percebida**: acesso contínuo à área logada do paciente.
+- **Mobile-first**: experiência otimizada para smartphone.
+- **Usabilidade**: navegação simples e direta para reduzir atrito em operações críticas.
+
+---
+
+## 9. Status do Projeto
+
+Projeto em fase de evolução incremental, com MVP centrado em agendamento e gestão de status, preparado para expansão modular em funcionalidades clínicas e operacionais futuras.

--- a/postman/globals/workspace.globals.yaml
+++ b/postman/globals/workspace.globals.yaml
@@ -1,0 +1,2 @@
+name: Globals
+values: []

--- a/src/main/java/com/pi/nutri/config/SecurityConfig.java
+++ b/src/main/java/com/pi/nutri/config/SecurityConfig.java
@@ -31,6 +31,8 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.POST, "/api/usuarios/login").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/usuarios/esqueci-senha").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/usuarios/reset-senha").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/agendas/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/agendas/**").permitAll()
                                 .anyRequest().authenticated())
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/pi/nutri/controller/AgendaController.java
+++ b/src/main/java/com/pi/nutri/controller/AgendaController.java
@@ -1,0 +1,41 @@
+package com.pi.nutri.controller;
+
+import com.pi.nutri.dto.Agenda.AgendaRequestDto;
+import com.pi.nutri.model.Agenda;
+import com.pi.nutri.service.AgendaService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/agendas")
+public class AgendaController {
+
+    private final AgendaService agendaService;
+
+    @Autowired
+    public AgendaController(AgendaService agendaService) {
+        this.agendaService = agendaService;
+    }
+
+    /**
+     * Listar todos os horários (Aux progresso)
+     */
+    @GetMapping
+    public ResponseEntity<List<Agenda>> listarTodas() {
+        return ResponseEntity.ok(agendaService.listarTodos());
+    }
+
+    /**
+     * EAP 4.3.3: Cadastra um novo slot de horário.
+     */
+    @PostMapping
+    public ResponseEntity<Agenda> cadastrarHorario(@RequestBody AgendaRequestDto dto) {
+        // A conversão de DTO para Model pode ser feita no Service
+        Agenda novaAgenda = agendaService.criarHorario(dto);
+        return new ResponseEntity<>(novaAgenda, HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/pi/nutri/dto/Agenda/AgendaRequestDto.java
+++ b/src/main/java/com/pi/nutri/dto/Agenda/AgendaRequestDto.java
@@ -1,0 +1,11 @@
+package com.pi.nutri.dto.Agenda;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record AgendaRequestDto(
+        LocalDate dataAgenda,
+        LocalTime horaAgenda,
+        Integer duracaoMinutos,
+        boolean isDisponivel
+) {}

--- a/src/main/java/com/pi/nutri/model/Agenda.java
+++ b/src/main/java/com/pi/nutri/model/Agenda.java
@@ -21,4 +21,8 @@ public class Agenda {
 
     @Column(name = "is_disponivel", nullable = false)
     private boolean isDisponivel;
+
+    //4.3.3 nasce aqui
+    @Column(name = "duracao_minutos", nullable = false)
+    private Integer duracaoMinutos;
 }

--- a/src/main/java/com/pi/nutri/service/AgendaService.java
+++ b/src/main/java/com/pi/nutri/service/AgendaService.java
@@ -1,0 +1,48 @@
+package com.pi.nutri.service;
+
+import com.pi.nutri.dto.Agenda.AgendaRequestDto;
+import com.pi.nutri.model.Agenda;
+import com.pi.nutri.repository.AgendaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+public class AgendaService {
+
+    private final AgendaRepository agendaRepository;
+
+    @Autowired
+    public AgendaService(AgendaRepository agendaRepository) {
+        this.agendaRepository = agendaRepository;
+    }
+
+    /**
+     * EAP 4.3.3: Lista todos os horários.
+     */
+    public List<Agenda> listarTodos() {
+        return agendaRepository.findAll();
+    }
+
+    /**
+     * EAP 4.3.3: Cria um novo slot de horário na agenda.
+     */
+    public Agenda criarHorario(AgendaRequestDto dto) {
+        Agenda agenda = new Agenda();
+        agenda.setDataAgenda(dto.dataAgenda());
+        agenda.setHoraAgenda(dto.horaAgenda());
+        // Regra da 4.3.3: Se a duração for nula no DTO, aplicar 30 como default
+        agenda.setDuracaoMinutos(dto.duracaoMinutos() != null ? dto.duracaoMinutos() : 30);
+        agenda.setDisponivel(dto.isDisponivel());
+
+        return agendaRepository.save(agenda);
+    }
+
+    /**
+     * Busca agendas por ID
+     */
+    public Agenda buscarPorId(Long id) {
+        return agendaRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Horário de agenda não encontrado"));
+    }
+}

--- a/src/main/java/com/pi/nutri/service/UsuarioService.java
+++ b/src/main/java/com/pi/nutri/service/UsuarioService.java
@@ -18,7 +18,7 @@ import com.pi.nutri.model.Usuario;
 import com.pi.nutri.repository.UsuarioRepository;
 import com.pi.nutri.service.Token.TokenService;
 
-import lombok.var;
+//import lombok.var;
 
 @Service
 public class UsuarioService {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,5 @@ spring.mail.username=nutripisenac@gmail.com
 spring.mail.password=vdchjlpzcyizabic
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+#logging.level.org.springframework=DEBUG

--- a/src/main/resources/db/migration/V3__alter_duracao_agenda.sql
+++ b/src/main/resources/db/migration/V3__alter_duracao_agenda.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agendas ADD duracao_minutos INT NOT NULL DEFAULT 30;


### PR DESCRIPTION
## // Descrição
Implementa a base lógica e de persistência para a gestão de horários da agenda. 
Este PR foca na funcionalidade de duração automatizada das consultas (EAP 4.3.3).

## // Alterações Realizadas
- Criado `AgendaRequestDto` para isolamento de entrada de dados.
- Implementada lógica de fallback no `AgendaService` (Default: 30 min).
- Desenvolvido `AgendaController` com endpoints de cadastro e listagem.
- Adicionado campo `duracao_minutos` ao mapeamento JPA e Migration SQL.
- Ajustado `SecurityConfig` para permitir testes de integração nos endpoints de agenda.

## // Teste
1. Execute a aplicação e verifique se o Flyway/Hibernate validou a nova coluna no SQL Server.
2. Utilize o Postman para realizar um POST em `/api/agendas` sem o campo `duracaoMinutos`.
3. Valide se o retorno apresenta o valor `30` por padrão.

## // Issues Relacionadas
- Closes #23 