### PR TITLE
Feat/18 autenticacao criptografia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NutriPI
 
-Plataforma web de marcação de consultas para consultórios, com foco em **agendamento direto pelo paciente**, **organização da grade médica** e **redução de faltas (absenteísmo)** por meio de fluxo digital integrado.
+Plataforma web de marcação de consultas para consultórios de nutrição, com foco em **agendamento direto pelo paciente**, **organização da grade do nutricionista** e **redução de faltas (absenteísmo)** por meio de fluxo digital integrado.
 
 ---
 
@@ -8,7 +8,7 @@ Plataforma web de marcação de consultas para consultórios, com foco em **agen
 
 O **NutriPI** nasce para substituir processos manuais de agendamento por uma experiência digital simples e centralizada, conectando:
 
-- **Médico**, que configura sua disponibilidade de atendimento;
+- **Nutricionista**, que configura sua disponibilidade de atendimento;
 - **Paciente**, que visualiza horários e realiza reservas pela área logada;
 - **Recepção**, que acompanha e gerencia o status das consultas.
 
@@ -26,7 +26,7 @@ No MVP, o sistema prioriza rapidez de operação, clareza no fluxo de marcação
 
 ### 2.2 Escopo
 
-O objetivo primordial do software é **automatizar a gestão de agendamentos em consultórios médicos**, eliminando tarefas manuais e combatendo faltas com notificações e controle de status.
+O objetivo primordial do software é **automatizar a gestão de agendamentos em consultórios de nutrição**, eliminando tarefas manuais e combatendo faltas com notificações e controle de status.
 
 O foco inicial está em:
 
@@ -58,7 +58,7 @@ O produto entrega uma plataforma de agendamento direto onde o consultório publi
 
 ### Incluído no MVP
 
-- Configuração de grade de horários do médico;
+- Configuração de grade de horários do nutricionista;
 - Visualização de disponibilidade para agendamento;
 - Agendamento direto pelo paciente em área autenticada;
 - Cadastro básico de paciente no primeiro agendamento;
@@ -80,7 +80,7 @@ O produto entrega uma plataforma de agendamento direto onde o consultório publi
 
 | Cod. | Nome                    | Descrição |
 |------|-------------------------|-----------|
-| F01  | Configuração de Grade   | O sistema deve permitir que o médico defina dias, horários de atendimento e duração padrão das consultas. |
+| F01  | Configuração de Grade   | O sistema deve permitir que o nutricionista defina dias, horários de atendimento e duração padrão das consultas. |
 | F02  | Agendamento Direto      | O paciente deve conseguir visualizar horários disponíveis e realizar reserva pela área logada do site. |
 | F03  | Gestão de Status        | A recepção deve poder marcar consultas como **Confirmada** ou **Cancelada**. |
 | F04  | Cadastro de Pacientes   | O sistema deve permitir registro básico de dados do paciente no momento do primeiro agendamento. |
@@ -100,7 +100,7 @@ O produto entrega uma plataforma de agendamento direto onde o consultório publi
 
 ```mermaid
 graph LR
-    Medico((Médico))
+    Nutricionista((Nutricionista))
     Paciente((Paciente))
     Recepcao((Recepção))
 
@@ -116,7 +116,7 @@ graph LR
         UC4 -. "<<extend>>" .-> UC2
     end
 
-    Medico --- UC1
+    Nutricionista --- UC1
     Paciente --- UC2
     Paciente --- UC5
     Recepcao --- UC6
@@ -124,7 +124,7 @@ graph LR
 
 ### 5.1 Atores
 
-- **Médico**: define agenda e janelas de atendimento.
+- **Nutricionista**: define agenda e janelas de atendimento.
 - **Paciente**: consulta disponibilidade, agenda e cancela consultas.
 - **Recepção**: valida atendimento operacional confirmando ou cancelando status.
 
@@ -137,7 +137,7 @@ graph LR
 
 ## 6. Personas do Sistema
 
-### 6.1 Persona 1 — Médico (Gestor de Agenda)
+### 6.1 Persona 1 — Nutricionista (Gestor de Agenda)
 
 - **Nome representativo**: Dr. Rafael (Nutrólogo/Nutricionista)
 - **Objetivo principal**: manter agenda organizada e previsível.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,206 @@
-# Nutri-PI
-𝗣𝗿𝗼𝗷𝗲𝘁𝗼 𝗜𝗻𝘁𝗲𝗴𝗿𝗮𝗱𝗼𝗿: 𝗗𝗲𝘀𝗲𝗻𝘃𝗼𝗹𝘃𝗶𝗺𝗲𝗻𝘁𝗼 𝗱𝗲 𝗦𝗶𝘀𝘁𝗲𝗺𝗮𝘀 𝗢𝗿𝗶𝗲𝗻𝘁𝗮𝗱𝗼𝘀 𝗮 𝗪𝗲𝗯 (𝗦𝗘𝗡𝗔𝗖-𝗦𝗣) Desenvolvimento da plataforma de agendamento para nutricionistas. Projeto pautado em metodologias ágeis (Scrum), com separação rigorosa entre Backend e Frontend e persistência de dados estruturada.
+# NutriPI
+
+Plataforma web de marcação de consultas para consultórios, com foco em **agendamento direto pelo paciente**, **organização da grade médica** e **redução de faltas (absenteísmo)** por meio de fluxo digital integrado.
+
+---
+
+## 1. Visão Geral do Produto
+
+O **NutriPI** nasce para substituir processos manuais de agendamento por uma experiência digital simples e centralizada, conectando:
+
+- **Médico**, que configura sua disponibilidade de atendimento;
+- **Paciente**, que visualiza horários e realiza reservas pela área logada;
+- **Recepção**, que acompanha e gerencia o status das consultas.
+
+No MVP, o sistema prioriza rapidez de operação, clareza no fluxo de marcação e base de dados padronizada para sustentar evoluções futuras do ecossistema.
+
+---
+
+## 2. Documento de Visão
+
+### 2.1 Histórico de Revisão
+
+| Data       | Versão | Descrição                         | Autores |
+|------------|--------|-----------------------------------|---------|
+| 04/03/2026 | 1.0    | Início do esboço do projeto       | Thiago Mendes Jatobá; Gabriel Lima; Gabriel Silva Gomes; Débora dos Santos da Silva; Marcos Paulo Santos Boe |
+
+### 2.2 Escopo
+
+O objetivo primordial do software é **automatizar a gestão de agendamentos em consultórios médicos**, eliminando tarefas manuais e combatendo faltas com notificações e controle de status.
+
+O foco inicial está em:
+
+- eficiência operacional interna do consultório;
+- conveniência para pacientes já vinculados à clínica;
+- consolidação de uma base de dados estruturada e consistente.
+
+### 2.3 Estratégia de Evolução
+
+A solução é concebida para escalar tecnicamente, com arquitetura preparada para:
+
+- atender múltiplos clientes em infraestrutura compartilhada (modelo multi-cliente);
+- manter isolamento operacional por consultório;
+- permitir evolução modular sem refatorar o núcleo.
+
+Módulos futuros previstos (fora do MVP):
+
+- triagem avançada;
+- faturamento hospitalar;
+- ecossistema ampliado de serviços de saúde.
+
+### 2.4 Resumo Executivo
+
+O produto entrega uma plataforma de agendamento direto onde o consultório publica sua grade e o paciente reserva horários pela aplicação web. O processo é apoiado por lembretes automáticos e por um painel simplificado para a recepção.
+
+---
+
+## 3. Escopo do MVP
+
+### Incluído no MVP
+
+- Configuração de grade de horários do médico;
+- Visualização de disponibilidade para agendamento;
+- Agendamento direto pelo paciente em área autenticada;
+- Cadastro básico de paciente no primeiro agendamento;
+- Gestão de status da consulta pela recepção (confirmar/cancelar);
+- Cancelamento de consulta pelo paciente (conforme diagrama de caso de uso).
+
+### Explicitamente fora do MVP
+
+- Motor de busca global de profissionais;
+- Gestão complexa de convênios;
+- Prontuário eletrônico completo;
+- Módulos financeiros.
+
+---
+
+## 4. Requisitos
+
+### 4.1 Requisitos Funcionais
+
+| Cod. | Nome                    | Descrição |
+|------|-------------------------|-----------|
+| F01  | Configuração de Grade   | O sistema deve permitir que o médico defina dias, horários de atendimento e duração padrão das consultas. |
+| F02  | Agendamento Direto      | O paciente deve conseguir visualizar horários disponíveis e realizar reserva pela área logada do site. |
+| F03  | Gestão de Status        | A recepção deve poder marcar consultas como **Confirmada** ou **Cancelada**. |
+| F04  | Cadastro de Pacientes   | O sistema deve permitir registro básico de dados do paciente no momento do primeiro agendamento. |
+
+### 4.2 Requisitos Não Funcionais
+
+| Cod. | Nome                  | Descrição |
+|------|-----------------------|-----------|
+| NF01 | Segurança (LGPD)      | Dados de saúde e identificação devem ser criptografados e armazenados conforme a LGPD. |
+| NF02 | Disponibilidade       | O paciente pode acessar sua área logada a qualquer momento para consultar informações. |
+| NF03 | Responsividade        | A interface de agendamento deve ser otimizada para dispositivos móveis (mobile-first). |
+| NF04 | Interface Intuitiva   | A solução deve ser simples de consultar, fácil de usar e preparada para escalar. |
+
+---
+
+## 5. Diagrama de Casos de Uso (MVP)
+
+```mermaid
+graph LR
+    Medico((Médico))
+    Paciente((Paciente))
+    Recepcao((Recepção))
+
+    subgraph "Sistema de Marcação de Consultas (MVP)"
+        UC1([Configurar Grade de Horários])
+        UC2([Realizar Agendamento])
+        UC3([Visualizar Disponibilidade])
+        UC4([Realizar Cadastro Básico])
+        UC5([Cancelar Consulta])
+        UC6([Gerenciar Status: Confirmar/Cancelar])
+
+        UC2 -. "<<include>>" .-> UC3
+        UC4 -. "<<extend>>" .-> UC2
+    end
+
+    Medico --- UC1
+    Paciente --- UC2
+    Paciente --- UC5
+    Recepcao --- UC6
+```
+
+### 5.1 Atores
+
+- **Médico**: define agenda e janelas de atendimento.
+- **Paciente**: consulta disponibilidade, agenda e cancela consultas.
+- **Recepção**: valida atendimento operacional confirmando ou cancelando status.
+
+### 5.2 Relações importantes
+
+- **Realizar Agendamento** inclui **Visualizar Disponibilidade**.
+- **Realizar Cadastro Básico** estende **Realizar Agendamento** quando o paciente ainda não possui registro.
+
+---
+
+## 6. Personas do Sistema
+
+### 6.1 Persona 1 — Médico (Gestor de Agenda)
+
+- **Nome representativo**: Dr. Rafael (Nutrólogo/Nutricionista)
+- **Objetivo principal**: manter agenda organizada e previsível.
+- **Necessidades**:
+  - configurar dias e horários de atendimento com facilidade;
+  - reduzir conflitos de agenda e horários vagos;
+  - ter segurança de que a recepção acompanha o status das consultas.
+- **Dores atuais**:
+  - remarcações manuais;
+  - dificuldade de consolidar agenda em canais dispersos.
+- **Como o NutriPI ajuda**:
+  - centraliza a grade de horários;
+  - padroniza reservas em um fluxo único.
+
+### 6.2 Persona 2 — Paciente (Usuário de Autoatendimento)
+
+- **Nome representativo**: Ana, 29 anos
+- **Objetivo principal**: marcar consulta de forma rápida e sem contato telefônico.
+- **Necessidades**:
+  - visualizar horários disponíveis em tempo real;
+  - concluir agendamento em poucos passos;
+  - acessar o sistema pelo celular com boa usabilidade;
+  - cancelar consulta quando necessário.
+- **Dores atuais**:
+  - demora em retorno por telefone/mensagem;
+  - falta de clareza sobre horários livres.
+- **Como o NutriPI ajuda**:
+  - oferece autoatendimento web em área autenticada;
+  - melhora experiência com interface responsiva e intuitiva.
+
+### 6.3 Persona 3 — Recepção (Operação Administrativa)
+
+- **Nome representativo**: Carla, recepcionista
+- **Objetivo principal**: manter controle diário da agenda e confirmar presença.
+- **Necessidades**:
+  - visualizar rapidamente consultas agendadas;
+  - alterar status para **Confirmada** ou **Cancelada**;
+  - reduzir erros operacionais e retrabalho.
+- **Dores atuais**:
+  - excesso de atualizações manuais;
+  - inconsistência de informações entre canais.
+- **Como o NutriPI ajuda**:
+  - fornece painel administrativo com visão centralizada;
+  - simplifica gestão de status em fluxo único.
+
+---
+
+## 7. Protótipos de Tela
+
+Protótipos disponíveis no Figma:  
+https://www.figma.com/design/WssgymwKX8ejjgaBu1Wrj6/NutriPi?node-id=0-1&p=f
+
+---
+
+## 8. Diretrizes de Qualidade do Produto
+
+- **Segurança e conformidade**: tratamento de dados conforme LGPD.
+- **Alta disponibilidade percebida**: acesso contínuo à área logada do paciente.
+- **Mobile-first**: experiência otimizada para smartphone.
+- **Usabilidade**: navegação simples e direta para reduzir atrito em operações críticas.
+
+---
+
+## 9. Status do Projeto
+
+Projeto em fase de evolução incremental, com MVP centrado em agendamento e gestão de status, preparado para expansão modular em funcionalidades clínicas e operacionais futuras.

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,31 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+
+		<!-- Spring Security -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<!-- JWT -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>25</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -40,7 +40,28 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc</artifactId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>
@@ -90,17 +111,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-flyway-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc-test</artifactId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/pi/nutri/config/PasswordConfig.java
+++ b/src/main/java/com/pi/nutri/config/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.pi.nutri.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/pi/nutri/config/SecurityConfig.java
+++ b/src/main/java/com/pi/nutri/config/SecurityConfig.java
@@ -1,0 +1,64 @@
+package com.pi.nutri.config;
+
+import com.pi.nutri.security.JwtAuthFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+    private final UserDetailsService userDetailsService;
+    private final PasswordEncoder passwordEncoder;
+
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter,
+                          UserDetailsService userDetailsService,
+                          PasswordEncoder passwordEncoder) {
+        this.jwtAuthFilter = jwtAuthFilter;
+        this.userDetailsService = userDetailsService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/usuarios").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/usuarios").hasRole("NUTRICIONISTA")
+                .anyRequest().authenticated()
+            )
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authenticationProvider(authenticationProvider())
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder);
+        return provider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/src/main/java/com/pi/nutri/controller/AuthController.java
+++ b/src/main/java/com/pi/nutri/controller/AuthController.java
@@ -1,0 +1,37 @@
+package com.pi.nutri.controller;
+
+import com.pi.nutri.dto.JwtResponseDTO;
+import com.pi.nutri.dto.LoginRequestDTO;
+import com.pi.nutri.security.JwtUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+
+    public AuthController(AuthenticationManager authenticationManager, JwtUtil jwtUtil) {
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<JwtResponseDTO> login(@RequestBody LoginRequestDTO request) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.email(), request.senha())
+        );
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        String token = jwtUtil.gerarToken(userDetails);
+        return ResponseEntity.ok(new JwtResponseDTO(token));
+    }
+}

--- a/src/main/java/com/pi/nutri/controller/UsuarioController.java
+++ b/src/main/java/com/pi/nutri/controller/UsuarioController.java
@@ -1,7 +1,9 @@
 package com.pi.nutri.controller;
 
-import java.util.List;
-
+import com.pi.nutri.dto.UsuarioCadastroDTO;
+import com.pi.nutri.dto.UsuarioResponseDTO;
+import com.pi.nutri.model.Usuario;
+import com.pi.nutri.service.UsuarioService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,12 +12,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.pi.nutri.model.Usuario;
-import com.pi.nutri.service.UsuarioService;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/usuarios")
 public class UsuarioController {
+
     private final UsuarioService usuarioService;
 
     public UsuarioController(UsuarioService usuarioService) {
@@ -23,15 +25,17 @@ public class UsuarioController {
     }
 
     @PostMapping
-    public ResponseEntity<Usuario> criarUsuario(@RequestBody Usuario usuario){
-        Usuario novoUsuario = usuarioService.salvarUsuario(usuario);
-        return ResponseEntity.status(HttpStatus.CREATED).body(novoUsuario);
+    public ResponseEntity<UsuarioResponseDTO> criarUsuario(@RequestBody UsuarioCadastroDTO dto) {
+        Usuario novoUsuario = usuarioService.salvarUsuario(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(UsuarioResponseDTO.de(novoUsuario));
     }
 
-
     @GetMapping
-    public ResponseEntity<List<Usuario>> listarUsuarios(){
-        List<Usuario> usuarios = usuarioService.listarUsuarios();
+    public ResponseEntity<List<UsuarioResponseDTO>> listarUsuarios() {
+        List<UsuarioResponseDTO> usuarios = usuarioService.listarUsuarios()
+                .stream()
+                .map(UsuarioResponseDTO::de)
+                .toList();
         return ResponseEntity.ok(usuarios);
     }
 }

--- a/src/main/java/com/pi/nutri/controller/UsuarioController.java
+++ b/src/main/java/com/pi/nutri/controller/UsuarioController.java
@@ -12,7 +12,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+<<<<<<< Updated upstream
 import java.util.List;
+=======
+import com.pi.nutri.dto.UsuarioResponseDTO;
+import com.pi.nutri.model.Usuario;
+import com.pi.nutri.service.UsuarioService;
+>>>>>>> Stashed changes
 
 @RestController
 @RequestMapping("/api/usuarios")
@@ -25,16 +31,26 @@ public class UsuarioController {
     }
 
     @PostMapping
+<<<<<<< Updated upstream
     public ResponseEntity<UsuarioResponseDTO> criarUsuario(@RequestBody UsuarioCadastroDTO dto) {
         Usuario novoUsuario = usuarioService.salvarUsuario(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(UsuarioResponseDTO.de(novoUsuario));
+=======
+    public ResponseEntity<UsuarioResponseDTO> criarUsuario(@RequestBody Usuario usuario) {
+        Usuario salvo = usuarioService.salvarUsuario(usuario);
+        return ResponseEntity.status(HttpStatus.CREATED).body(UsuarioResponseDTO.from(salvo));
+>>>>>>> Stashed changes
     }
 
     @GetMapping
     public ResponseEntity<List<UsuarioResponseDTO>> listarUsuarios() {
         List<UsuarioResponseDTO> usuarios = usuarioService.listarUsuarios()
                 .stream()
+<<<<<<< Updated upstream
                 .map(UsuarioResponseDTO::de)
+=======
+                .map(UsuarioResponseDTO::from)
+>>>>>>> Stashed changes
                 .toList();
         return ResponseEntity.ok(usuarios);
     }

--- a/src/main/java/com/pi/nutri/dto/JwtResponseDTO.java
+++ b/src/main/java/com/pi/nutri/dto/JwtResponseDTO.java
@@ -1,0 +1,8 @@
+package com.pi.nutri.dto;
+
+public record JwtResponseDTO(String token, String tipo) {
+
+    public JwtResponseDTO(String token) {
+        this(token, "Bearer");
+    }
+}

--- a/src/main/java/com/pi/nutri/dto/LoginRequestDTO.java
+++ b/src/main/java/com/pi/nutri/dto/LoginRequestDTO.java
@@ -1,0 +1,3 @@
+package com.pi.nutri.dto;
+
+public record LoginRequestDTO(String email, String senha) {}

--- a/src/main/java/com/pi/nutri/dto/LoginResponseDTO.java
+++ b/src/main/java/com/pi/nutri/dto/LoginResponseDTO.java
@@ -1,0 +1,3 @@
+package com.pi.nutri.dto;
+
+public record LoginResponseDTO(String token) {}

--- a/src/main/java/com/pi/nutri/dto/UsuarioCadastroDTO.java
+++ b/src/main/java/com/pi/nutri/dto/UsuarioCadastroDTO.java
@@ -1,0 +1,3 @@
+package com.pi.nutri.dto;
+
+public record UsuarioCadastroDTO(String nome, String email, String senha, boolean isNutri, String crn) {}

--- a/src/main/java/com/pi/nutri/dto/UsuarioResponseDTO.java
+++ b/src/main/java/com/pi/nutri/dto/UsuarioResponseDTO.java
@@ -1,0 +1,16 @@
+package com.pi.nutri.dto;
+
+import com.pi.nutri.model.Usuario;
+
+public record UsuarioResponseDTO(Long id, String nome, String email, boolean isNutri, String crn) {
+
+    public static UsuarioResponseDTO de(Usuario usuario) {
+        return new UsuarioResponseDTO(
+                usuario.getId(),
+                usuario.getNome(),
+                usuario.getEmail(),
+                usuario.isNutri(),
+                usuario.getCrn()
+        );
+    }
+}

--- a/src/main/java/com/pi/nutri/model/Consulta.java
+++ b/src/main/java/com/pi/nutri/model/Consulta.java
@@ -15,8 +15,8 @@ public class Consulta {
     private Usuario usuario;
 
     @OneToOne
-    private Agenda agenda;
     @JoinColumn(name = "agenda_id", nullable = false, unique = true)
+    private Agenda agenda;
 
     @Column(nullable = false, length = 20)
     private String status = "AGENDADA";    

--- a/src/main/java/com/pi/nutri/model/Usuario.java
+++ b/src/main/java/com/pi/nutri/model/Usuario.java
@@ -1,5 +1,6 @@
 package com.pi.nutri.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Data;
 @Data
@@ -19,6 +20,7 @@ public class Usuario {
     @Column(nullable = false)
     private String senha;
 
+    @JsonProperty("isNutri")
     @Column(name = "is_nutri", nullable = false)
     private boolean isNutri;
 

--- a/src/main/java/com/pi/nutri/repository/UsuarioRepository.java
+++ b/src/main/java/com/pi/nutri/repository/UsuarioRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.pi.nutri.model.Usuario;
 
+import java.util.Optional;
+
 public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
-    
+
+    Optional<Usuario> findByEmail(String email);
 }

--- a/src/main/java/com/pi/nutri/repository/UsuarioRepository.java
+++ b/src/main/java/com/pi/nutri/repository/UsuarioRepository.java
@@ -1,5 +1,7 @@
 package com.pi.nutri.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.pi.nutri.model.Usuario;
@@ -7,6 +9,9 @@ import com.pi.nutri.model.Usuario;
 import java.util.Optional;
 
 public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
+<<<<<<< Updated upstream
 
+=======
+>>>>>>> Stashed changes
     Optional<Usuario> findByEmail(String email);
 }

--- a/src/main/java/com/pi/nutri/security/JwtAuthFilter.java
+++ b/src/main/java/com/pi/nutri/security/JwtAuthFilter.java
@@ -1,0 +1,56 @@
+package com.pi.nutri.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthFilter(JwtUtil jwtUtil, UserDetailsService userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = header.substring(7);
+        String email = jwtUtil.extrairEmail(token);
+
+        if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+            if (jwtUtil.validarToken(token, userDetails)) {
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/pi/nutri/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pi/nutri/security/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package com.pi.nutri.security;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtService jwtService, UserDetailsService userDetailsService) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7);
+
+        try {
+            String email = jwtService.extractUsername(token);
+            log.info("JWT - email extraído: {}", email);
+
+            if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                boolean valid = jwtService.isTokenValid(token, userDetails);
+                log.info("JWT - token válido: {}, authorities: {}", valid, userDetails.getAuthorities());
+
+                if (valid) {
+                    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContext context = SecurityContextHolder.createEmptyContext();
+                    context.setAuthentication(authToken);
+                    SecurityContextHolder.setContext(context);
+                }
+            }
+        } catch (Exception e) {
+            log.error("JWT filter error: {}", e.getMessage());
+            SecurityContextHolder.clearContext();
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/pi/nutri/security/JwtSecurityContextRepository.java
+++ b/src/main/java/com/pi/nutri/security/JwtSecurityContextRepository.java
@@ -1,0 +1,65 @@
+package com.pi.nutri.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.context.HttpRequestResponseHolder;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+@SuppressWarnings("deprecation")
+public class JwtSecurityContextRepository implements SecurityContextRepository {
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    public JwtSecurityContextRepository(JwtService jwtService, UserDetailsService userDetailsService) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    public SecurityContext loadContext(HttpRequestResponseHolder holder) {
+        return load(holder.getRequest());
+    }
+
+    @Override
+    public void saveContext(SecurityContext context, HttpServletRequest request, HttpServletResponse response) {
+    }
+
+    @Override
+    public boolean containsContext(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        return header != null && header.startsWith("Bearer ");
+    }
+
+    private SecurityContext load(HttpServletRequest request) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        String header = request.getHeader("Authorization");
+
+        if (header == null || !header.startsWith("Bearer ")) {
+            return context;
+        }
+
+        String token = header.substring(7);
+        try {
+            String email = jwtService.extractUsername(token);
+            if (email != null) {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                if (jwtService.isTokenValid(token, userDetails)) {
+                    context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities()));
+                }
+            }
+        } catch (Exception ignored) {
+        }
+
+        return context;
+    }
+}

--- a/src/main/java/com/pi/nutri/security/JwtService.java
+++ b/src/main/java/com/pi/nutri/security/JwtService.java
@@ -1,0 +1,63 @@
+package com.pi.nutri.security;
+
+import java.util.Date;
+import java.util.function.Function;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+@Service
+public class JwtService {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expiration;
+
+    public String generateToken(UserDetails userDetails) {
+        return Jwts.builder()
+                .subject(userDetails.getUsername())
+                .claim("roles", userDetails.getAuthorities().stream()
+                        .map(a -> a.getAuthority())
+                        .toList())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(signingKey())
+                .compact();
+    }
+
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        String username = extractUsername(token);
+        return username.equals(userDetails.getUsername()) && !isExpired(token);
+    }
+
+    private boolean isExpired(String token) {
+        return extractClaim(token, Claims::getExpiration).before(new Date());
+    }
+
+    private <T> T extractClaim(String token, Function<Claims, T> resolver) {
+        Claims claims = Jwts.parser()
+                .verifyWith(signingKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return resolver.apply(claims);
+    }
+
+    private SecretKey signingKey() {
+        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+    }
+}

--- a/src/main/java/com/pi/nutri/security/JwtUtil.java
+++ b/src/main/java/com/pi/nutri/security/JwtUtil.java
@@ -1,0 +1,65 @@
+package com.pi.nutri.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expiration;
+
+    public String gerarToken(UserDetails userDetails) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("roles", userDetails.getAuthorities().stream()
+                .map(a -> a.getAuthority())
+                .toList());
+        return Jwts.builder()
+                .claims(claims)
+                .subject(userDetails.getUsername())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getChave())
+                .compact();
+    }
+
+    public String extrairEmail(String token) {
+        return extrairClaim(token, Claims::getSubject);
+    }
+
+    public boolean validarToken(String token, UserDetails userDetails) {
+        String email = extrairEmail(token);
+        return email.equals(userDetails.getUsername()) && !isExpirado(token);
+    }
+
+    private boolean isExpirado(String token) {
+        return extrairClaim(token, Claims::getExpiration).before(new Date());
+    }
+
+    private <T> T extrairClaim(String token, Function<Claims, T> resolver) {
+        Claims claims = Jwts.parser()
+                .verifyWith(getChave())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return resolver.apply(claims);
+    }
+
+    private SecretKey getChave() {
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/pi/nutri/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/pi/nutri/security/UserDetailsServiceImpl.java
@@ -1,0 +1,34 @@
+package com.pi.nutri.security;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.pi.nutri.model.Usuario;
+import com.pi.nutri.repository.UsuarioRepository;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UsuarioRepository usuarioRepository;
+
+    public UserDetailsServiceImpl(UsuarioRepository usuarioRepository) {
+        this.usuarioRepository = usuarioRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Usuario usuario = usuarioRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
+
+        String role = usuario.isNutri() ? "ROLE_NUTRI" : "ROLE_PACIENTE";
+
+        return User.builder()
+                .username(usuario.getEmail())
+                .password(usuario.getSenha())
+                .authorities(role)
+                .build();
+    }
+}

--- a/src/main/java/com/pi/nutri/service/UsuarioService.java
+++ b/src/main/java/com/pi/nutri/service/UsuarioService.java
@@ -1,25 +1,36 @@
 package com.pi.nutri.service;
 
-import java.util.List;
-import java.util.Optional;
-
-import org.springframework.stereotype.Service;
-
+import com.pi.nutri.dto.UsuarioCadastroDTO;
 import com.pi.nutri.model.Usuario;
 import com.pi.nutri.repository.UsuarioRepository;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
 
-import lombok.var;
+import java.util.List;
 
 @Service
-public class UsuarioService {
+public class UsuarioService implements UserDetailsService {
 
-    UsuarioRepository usuarioRepository;
+    private final UsuarioRepository usuarioRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public UsuarioService(UsuarioRepository repository) {
-        this.usuarioRepository = repository;
+    public UsuarioService(UsuarioRepository usuarioRepository, PasswordEncoder passwordEncoder) {
+        this.usuarioRepository = usuarioRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
-    public Usuario salvarUsuario(Usuario usuario) {
+    public Usuario salvarUsuario(UsuarioCadastroDTO dto) {
+        Usuario usuario = new Usuario();
+        usuario.setNome(dto.nome());
+        usuario.setEmail(dto.email());
+        usuario.setSenha(passwordEncoder.encode(dto.senha()));
+        usuario.setNutri(dto.isNutri());
+        usuario.setCrn(dto.crn());
         return usuarioRepository.save(usuario);
     }
 
@@ -27,4 +38,16 @@ public class UsuarioService {
         return usuarioRepository.findAll();
     }
 
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Usuario usuario = usuarioRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado: " + email));
+
+        String role = usuario.isNutri() ? "ROLE_NUTRICIONISTA" : "ROLE_PACIENTE";
+        return new User(
+                usuario.getEmail(),
+                usuario.getSenha(),
+                List.of(new SimpleGrantedAuthority(role))
+        );
+    }
 }

--- a/src/main/java/com/pi/nutri/service/UsuarioService.java
+++ b/src/main/java/com/pi/nutri/service/UsuarioService.java
@@ -1,6 +1,14 @@
 package com.pi.nutri.service;
 
+<<<<<<< Updated upstream
 import com.pi.nutri.dto.UsuarioCadastroDTO;
+=======
+import java.util.List;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+>>>>>>> Stashed changes
 import com.pi.nutri.model.Usuario;
 import com.pi.nutri.repository.UsuarioRepository;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -11,8 +19,11 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+<<<<<<< Updated upstream
 import java.util.List;
 
+=======
+>>>>>>> Stashed changes
 @Service
 public class UsuarioService implements UserDetailsService {
 
@@ -24,6 +35,7 @@ public class UsuarioService implements UserDetailsService {
         this.passwordEncoder = passwordEncoder;
     }
 
+<<<<<<< Updated upstream
     public Usuario salvarUsuario(UsuarioCadastroDTO dto) {
         Usuario usuario = new Usuario();
         usuario.setNome(dto.nome());
@@ -31,12 +43,17 @@ public class UsuarioService implements UserDetailsService {
         usuario.setSenha(passwordEncoder.encode(dto.senha()));
         usuario.setNutri(dto.isNutri());
         usuario.setCrn(dto.crn());
+=======
+    public Usuario salvarUsuario(Usuario usuario) {
+        usuario.setSenha(passwordEncoder.encode(usuario.getSenha()));
+>>>>>>> Stashed changes
         return usuarioRepository.save(usuario);
     }
 
     public List<Usuario> listarUsuarios() {
         return usuarioRepository.findAll();
     }
+<<<<<<< Updated upstream
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
@@ -50,4 +67,6 @@ public class UsuarioService implements UserDetailsService {
                 List.of(new SimpleGrantedAuthority(role))
         );
     }
+=======
+>>>>>>> Stashed changes
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,7 @@ spring.jpa.properties.hibernate.format_sql=true
 
 # Configurações do Flyway (Migrations)
 spring.flyway.enabled=true
+
+# JWT
+jwt.secret=nutri-pi-jwt-chave-secreta-segura-minimo-256-bits-2024
+jwt.expiration=86400000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,5 +16,9 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.flyway.enabled=true
 
 # JWT
+<<<<<<< Updated upstream
 jwt.secret=nutri-pi-jwt-chave-secreta-segura-minimo-256-bits-2024
+=======
+jwt.secret=bnV0cmktcGktand0LXNlY3JldC1rZXktMjU2Yml0cy0yMDI2LXNlY3VyZQ==
+>>>>>>> Stashed changes
 jwt.expiration=86400000


### PR DESCRIPTION
## O que foi implementado

- Cadastro de usuário retorna 201 com hash BCrypt na senha (campo senha omitido na resposta)
- Login via POST /api/auth/login retorna token JWT válido por 24h
- Credenciais inválidas retornam 401 Unauthorized
- GET /api/usuarios protegido por perfil:
  - Sem token → 401
  - Token de paciente → 403
  - Token de nutricionista → 200

## Arquivos adicionados
- `config/SecurityConfig.java` — configuração do Spring Security (stateless, CSRF desabilitado)
- `security/JwtService.java` — geração e validação de tokens JWT (HS256)
- `security/JwtSecurityContextRepository.java` — integração JWT com Spring Security 7
- `security/UserDetailsServiceImpl.java` — carrega usuário por email, define roles
- `controller/AuthController.java` — endpoint de login
- `dto/LoginRequestDTO`, `LoginResponseDTO`, `UsuarioResponseDTO` — DTOs sem campo senha

## Arquivos modificados
- `pom.xml` — Spring Security + JJWT 0.12.6
- `UsuarioService.java` — hash BCrypt na senha ao salvar
- `UsuarioController.java` — resposta via DTO (sem senha)
- `UsuarioRepository.java` — método `findByEmail`
- `application.properties` — configuração JWT (secret + expiração)